### PR TITLE
dee/ Removes "daily" tab and simplifies context render cycle

### DIFF
--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Tab } from "./Tab";
 
 const TABS = {
-  DAILY: "#333333",
   THU: "#02597F",
   FRI: "#1FB2A3",
   SAT: "#FAAF40",

--- a/src/components/header/Menu.jsx
+++ b/src/components/header/Menu.jsx
@@ -9,14 +9,6 @@ export const Menu = () => {
   const { date: headingText } = useDate();
   const { filter, FILTERS, handleFilterFavorites } = useFilter();
 
-  const color = {
-    DAILY: "#333333",
-    THU: "#02597F",
-    FRI: "#1FB2A3",
-    SAT: "#FAAF40",
-    SUN: "#D9533D",
-  };
-
   return (
     <div className="menu-accordion-wrapper">
       <div className="menu-accordion-content" onClick={() => setMenu(!menu)}>

--- a/src/state/StateProvider.js
+++ b/src/state/StateProvider.js
@@ -1,4 +1,10 @@
-import React, { useState, createContext, useContext, useEffect } from "react";
+import React, {
+  useState,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+} from "react";
 import data from "../../assets/data/events.json";
 
 export const UserContext = createContext();
@@ -12,7 +18,6 @@ const FILTERS = {
 };
 
 const DAYS = {
-  DAILY: "DAILY",
   THU: "Thursday",
   FRI: "Friday",
   SAT: "Saturday",
@@ -20,7 +25,6 @@ const DAYS = {
 };
 
 const DAY_HEADINGS = {
-  DAILY: "Recurring events",
   THU: "Thursday, May 23rd",
   FRI: "Friday, May 24th",
   SAT: "Saturday, May 25th",
@@ -31,14 +35,12 @@ export function StateProvider({ children }) {
   const [loading, setLoading] = useState(false);
   const [filter, setFilter] = useState("");
   const [menu, setMenu] = useState(false);
-  const [events, setEvents] = useState(data);
   const [favorites, setFavorites] = useState(() => {
     // Check local storage if favorites exist, otherwise initialize an empty array
     const cachedFavorites = localStorage.getItem("favorites");
     return cachedFavorites ? JSON.parse(cachedFavorites) : [];
   });
-  const [activeTab, setActiveTab] = useState(DAYS.DAILY);
-  const [date, setDate] = useState(DAY_HEADINGS.DAILY);
+  const [activeTab, setActiveTab] = useState("THU");
   const [query, setQuery] = useState("");
 
   // Handles toggling the filter view between favorited events and all events
@@ -85,34 +87,27 @@ export function StateProvider({ children }) {
     setQuery(query);
   };
 
-  useEffect(() => {
-    // Update local storage whenever favorites state changes
-    localStorage.setItem("favorites", JSON.stringify(favorites));
+  const date = useMemo(() => DAY_HEADINGS[activeTab], [activeTab]);
 
-    setDate(DAY_HEADINGS[activeTab]);
-
-    const filteredEvents = data.filter((event) => {
+  const filteredEvents = useMemo(() => {
+    return data.filter((event) => {
       const filterByFavorites =
         filter === FILTERS.FAVORITES
           ? favorites.some((favorite) => favorite.id === event.id)
           : true;
-
-      const filterByActiveTab =
-        activeTab === DAYS.DAILY
-          ? event.daily
-          : !event.daily && event.day === DAYS[activeTab];
-
+      const filterByActiveTab = event.day === DAYS[activeTab];
       const filterBySearchQuery = query
         ? [event.what, event.where, event.area].some((attr) =>
             attr?.toLowerCase().includes(query.toLowerCase())
           )
         : true;
-
       return filterByFavorites && filterByActiveTab && filterBySearchQuery;
     });
-
-    setEvents(filteredEvents);
   }, [favorites, activeTab, filter, query]);
+
+  useEffect(() => {
+    localStorage.setItem("favorites", JSON.stringify(favorites));
+  }, [favorites]);
 
   return (
     <UserContext.Provider
@@ -123,8 +118,8 @@ export function StateProvider({ children }) {
         setFilter,
         menu,
         setMenu,
-        events,
-        setEvents,
+        events: filteredEvents,
+        setEvents: () => {},
         handleFilterFavorites,
         handleToggleFavorited,
         handleFavoriteDisplay,

--- a/src/state/StateProvider.js
+++ b/src/state/StateProvider.js
@@ -89,7 +89,7 @@ export function StateProvider({ children }) {
 
   const date = useMemo(() => DAY_HEADINGS[activeTab], [activeTab]);
 
-  const filteredEvents = useMemo(() => {
+  const events = useMemo(() => {
     return data.filter((event) => {
       const filterByFavorites =
         filter === FILTERS.FAVORITES
@@ -118,8 +118,7 @@ export function StateProvider({ children }) {
         setFilter,
         menu,
         setMenu,
-        events: filteredEvents,
-        setEvents: () => {},
+        events,
         handleFilterFavorites,
         handleToggleFavorited,
         handleFavoriteDisplay,


### PR DESCRIPTION
#### Description 

This PR removes the "daily" tab, and updates filtering logic in the state provider to accommodate this. It also makes improvements to the recompute overhead by memoizing certain pieces of data (like the date for the heading text and filtered events). 

<img width="341" alt="image" src="https://github.com/WWW-Wizards/SOAK-WWW/assets/45681154/1eccff53-8714-4a1b-a92f-75473d7e511e">
