### PR TITLE
fix/ Corrects date parsing logic that caused events to sort out of order

### DIFF
--- a/assets/data/events.json
+++ b/assets/data/events.json
@@ -4843,7 +4843,7 @@
     "when": "05:45 PM-07:15 PM",
     "eventType": "Class/Workshop",
     "what": "qualiTEA touch — A consent driven, hands on—or hands off—embodiment workshop, facilitated by licensed massage therapists. We invite participants to mindfully engage with self, partnered, or group touch. Through deep listening/experiencing, we connect conscious understanding with nervous system knowing. Come for attuned bodywork, stay for discussion and tea service to follow. Seating",
-    "where": "Fortunia Tea House",
+    "where": "Fortunia",
     "area": "Forest Entry"
   },
   {

--- a/src/state/StateProvider.js
+++ b/src/state/StateProvider.js
@@ -198,11 +198,10 @@ export const parseStartTime = (str) => {
   const [start, period] = (str ?? "").split("-")[0].split(" ");
   const [startHour, startMinute] = start.split(":");
 
-  return (
-    (parseInt(startHour) % 12) +
-    (period === "PM" ? 12 : 0) * 60 +
-    parseInt(startMinute)
-  );
+  const hour = (parseInt(startHour) % 12) + (period === "PM" ? 12 : 0);
+  const minute = parseInt(startMinute);
+
+  return hour * 60 + minute;
 };
 
 export const parseEndTime = (str) => {


### PR DESCRIPTION
#### Description 

Fixes a bug with the sorting logic to properly account for events that start at a time where the minutes are non-zero (for example 5:45 PM, rather than 5:00 PM).

Scrolled to the bottom of Thursday's events, compare localhost:
<img width="345" alt="image" src="https://github.com/WWW-Wizards/SOAK-WWW/assets/45681154/5ebb9148-09bc-4ed6-b9cf-477fee09e0d7">

With main:
<img width="385" alt="image" src="https://github.com/WWW-Wizards/SOAK-WWW/assets/45681154/dc2be192-56f2-4349-b825-6fabd184a2ee">
